### PR TITLE
swarm update to version 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8u102-jdk
 
 MAINTAINER Carlos Sanchez <carlos@apache.org>
 
-ENV JENKINS_SWARM_VERSION 2.2
+ENV JENKINS_SWARM_VERSION 3.3
 ENV HOME /home/jenkins-slave
 
 # install netstat to allow connection health check with
@@ -10,7 +10,7 @@ ENV HOME /home/jenkins-slave
 RUN apt-get update && apt-get install -y net-tools && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -c "Jenkins Slave user" -d $HOME -m jenkins-slave
-RUN curl --create-dirs -sSLo /usr/share/jenkins/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar \
+RUN curl --create-dirs -sSLo /usr/share/jenkins/swarm-client-$JENKINS_SWARM_VERSION.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION.jar \
   && chmod 755 /usr/share/jenkins
 
 COPY jenkins-slave.sh /usr/local/bin/jenkins-slave.sh


### PR DESCRIPTION
Swarm plugin version update.

Artifacts are released under https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.3/ without `jar-with-dependencies` suffix. 

See also https://github.com/jenkinsci/swarm-plugin/tree/swarm-plugin-3.3