### PR TITLE
Update Jenkins Swarm Version to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8u102-jdk
 
 MAINTAINER Carlos Sanchez <carlos@apache.org>
 
-ENV JENKINS_SWARM_VERSION 3.9
+ENV JENKINS_SWARM_VERSION 3.12
 ENV HOME /home/jenkins-slave
 
 # install netstat to allow connection health check with


### PR DESCRIPTION
For compatibility with Jenkins LTS 2.121, see [Upgrade guide](https://jenkins.io/doc/upgrade-guide/2.121/)