### PR TITLE
Update swarm-client version to 3.14 (pi)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8u102-jdk
 
 MAINTAINER Carlos Sanchez <carlos@apache.org>
 
-ENV JENKINS_SWARM_VERSION 3.12
+ENV JENKINS_SWARM_VERSION 3.14
 ENV HOME /home/jenkins-slave
 
 # install netstat to allow connection health check with


### PR DESCRIPTION
swarm-client version 3.14 was release on September 4, 2018