### PR TITLE
Update to latest 8-jdk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8u102-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER Carlos Sanchez <carlos@apache.org>
 
-ENV JENKINS_SWARM_VERSION 3.14
+ENV JENKINS_SWARM_VERSION 3.15
 ENV HOME /home/jenkins-slave
 
 # install netstat to allow connection health check with


### PR DESCRIPTION
The current docker build is broken. This PR is intended to update the image back to working order.

Error log of current image:
```
Building in Docker Cloud's infrastructure...
Cloning into '.'...
Warning: Permanently added the RSA host key for IP address '192.30.253.112' to the list of known hosts.
Reset branch 'master'
Your branch is up-to-date with 'origin/master'.
KernelVersion: 4.4.0-1060-aws
Components: [{u'Version': u'18.03.1-ee-3', u'Name': u'Engine', u'Details': {u'KernelVersion': u'4.4.0-1060-aws', u'Os': u'linux', u'BuildTime': u'2018-08-30T18:42:30.000000000+00:00', u'ApiVersion': u'1.37', u'MinAPIVersion': u'1.12', u'GitCommit': u'b9a5c95', u'Arch': u'amd64', u'Experimental': u'false', u'GoVersion': u'go1.10.2'}}]
Arch: amd64
BuildTime: 2018-08-30T18:42:30.000000000+00:00
ApiVersion: 1.37
Platform: {u'Name': u''}
Version: 18.03.1-ee-3
MinAPIVersion: 1.12
GitCommit: b9a5c95
Os: linux
GoVersion: go1.10.2
Starting build of index.docker.io/krumware/jenkins-swarm-slave-docker:latest...
Step 1/11 : FROM openjdk:8u102-jdk
---> ca5dd051db43
Step 2/11 : MAINTAINER Carlos Sanchez <carlos@apache.org>
---> Running in 359757c644ff
Removing intermediate container 359757c644ff
---> 574bfcab537f
Step 3/11 : ENV JENKINS_SWARM_VERSION 3.14
---> Running in 29b28b534ad7
Removing intermediate container 29b28b534ad7
---> aa6b7e6422ed
Step 4/11 : ENV HOME /home/jenkins-slave
---> Running in a446d451015c
Removing intermediate container a446d451015c
---> 3fb2059afac4
Step 5/11 : RUN apt-get update && apt-get install -y net-tools && rm -rf /var/lib/apt/lists/*
---> Running in 53ee670546e3
Ign http://deb.debian.org jessie InRelease
Get:1 http://deb.debian.org jessie-updates InRelease [7340 B]
Get:2 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie-backports InRelease
Get:3 http://deb.debian.org jessie Release.gpg [2420 B]
Ign http://deb.debian.org jessie-backports Release.gpg
Get:4 http://deb.debian.org jessie Release [148 kB]
Ign http://deb.debian.org jessie-backports Release
Err http://deb.debian.org jessie-backports/main amd64 Packages
Err http://deb.debian.org jessie-backports/main amd64 Packages
Err http://deb.debian.org jessie-backports/main amd64 Packages
Err http://deb.debian.org jessie-backports/main amd64 Packages
Err http://deb.debian.org jessie-backports/main amd64 Packages
404 Not Found
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [843 kB]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Fetched 10.1 MB in 33s (301 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-backports/main/binary-amd64/Packages 404 Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
Removing intermediate container 53ee670546e3
The command '/bin/sh -c apt-get update && apt-get install -y net-tools && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```