### PR TITLE
Update to latest swarm-slave (3.17 - June 2, 2019)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jdk
 
 MAINTAINER Carlos Sanchez <carlos@apache.org>
 
-ENV JENKINS_SWARM_VERSION 3.15
+ENV JENKINS_SWARM_VERSION 3.17
 ENV HOME /home/jenkins-slave
 
 # install netstat to allow connection health check with


### PR DESCRIPTION
This updates the swarm slave version to the latest as of this commit.
Changelog here:
https://wiki.jenkins.io/display/JENKINS/Swarm+Plugin
