### PR TITLE
Add whitespaces to correct missing bracket warning

### DIFF
--- a/jenkins-slave.sh
+++ b/jenkins-slave.sh
@@ -20,13 +20,13 @@ if [[ $# -lt 1 ]] || [[ "$1" == "-"* ]]; then
       if [ ! -z "$CANDIDATE_TAG"]; then
         PARAMS="$PARAMS -candidateTag $CANDIDATE_TAG"
       fi
-      if [ "${DELETE_EXISTING_CLIENTS}x" = "truex"]; then
+      if [ "${DELETE_EXISTING_CLIENTS}x" = "truex" ]; then
         PARAMS="$PARAMS -deleteExistingClients"
       fi
-      if [ "${DISABLE_CLIENTS_UNIQUE_ID}x" = "truex"]; then
+      if [ "${DISABLE_CLIENTS_UNIQUE_ID}x" = "truex" ]; then
         PARAMS="$PARAMS -disableClientsUniqueId"
       fi
-      if [ "${DISABLE_SSL_VERIFICATION}x" = "truex"]; then
+      if [ "${DISABLE_SSL_VERIFICATION}x" = "truex" ]; then
         PARAMS="$PARAMS -disableSslVerification"
       fi
       if [ ! -z "$EXECUTORS" ]; then


### PR DESCRIPTION
Trivial change to avoid missing ] messages in container logs